### PR TITLE
bgp: add topo for bgp roles

### DIFF
--- a/bgp/bgp-roles/munet.yaml
+++ b/bgp/bgp-roles/munet.yaml
@@ -1,0 +1,133 @@
+# rt1       rt2       rt3       rt4       rt5       rt6
+#  |         |         |         |         |         |
+#  |--p-c----|         |         |         |         |
+#  |         |---c-p---|         |         |         |
+#  |         |         |--pr-pr--|         |         |
+#  |         |         |         |--c-p----|         |
+#  |         |         |         |         |--p-c----|
+#  [1.1.1.1] [2.2.2.2] [3.3.3.3] [4.4.4.4] [5.5.5.5] [6.6.6.6]
+#
+# Key
+# ---
+# p: provider role
+# c: customer role
+# pr: peer role
+#
+# Expected routes installed in each router via BGP (based on roles):
+# rt1: [rt2 routes]
+# rt2: [rt1 routes, rt3 routes, rt4 routes]
+# rt3: [rt2 routes, rt4 routes]
+# rt4: [rt2 routes, rt3 routes, rt5 routes, rt6 routes]
+# rt5: [rt4 routes, rt6 routes]
+# rt6: [rt4 routes, rt5 routes]
+
+version: 1
+kinds:
+  - name : holo
+    cmd: |
+      protocol_name=holo-bgp
+      topology_name=topo1-3
+      sleep_time=60
+      events_file=holo-events-bgp-main.jsonl
+      cd /tmp/munet/${MUNET_NODENAME}/holo.setup
+      ./setup.sh ${protocol_name} ${topology_name} ${sleep_time} ${events_file}
+
+    volumes:
+      - "./%NAME%/etc.holo:/etc/holo/"
+      - "%RUNDIR%/var.log:/var/log"
+      - "%RUNDIR%/var.opt.holo:/var/opt/holo"
+      - "%CONFIGDIR%/../../setup:%RUNDIR%/holo.setup"
+
+topology:
+  ipv6-enable: true
+  networks:
+    - name: net1
+    - name: net2
+    - name: net3
+    - name: net4
+    - name: net5
+
+    - name: net-test
+
+  nodes:
+    - name: rt1
+      kind: holo
+      connections:
+        - name: "eht-rt2"
+          to: net1
+          ip: 192.168.0.1/30
+
+        - name: "eth-test"
+          to: net-test
+          ip: 10.0.1.1/24
+
+    - name: rt2
+      kind: holo
+      connections:
+        - name: "eth-rt1"
+          to: net1
+          ip: 192.168.0.2/30
+
+        - name: eth-rt3
+          to: net2
+          ip: 192.168.0.5/30
+
+        - name: "eth-test"
+          to: net-test
+          ip: 10.0.2.1/24
+
+    - name: rt3
+      kind: holo
+      connections:
+        - name: eth-rt2
+          to: net2
+          ip: 192.168.0.6/30
+
+        - name: eth-rt4
+          to: net3
+          ip: 192.168.0.9/30
+
+        - name: eth-test
+          to: net-test
+          ip: 10.0.3.1/24
+
+    - name: rt4
+      kind: holo
+      connections:
+        - name: eth-rt3
+          to: net3
+          ip: 192.168.0.10/30
+
+        - name: eth-rt5
+          to: net4
+          ip: 192.168.0.13/30
+
+        - name: eth-test
+          to: net-test
+          ip: 10.0.4.1/24
+
+    - name: rt5
+      kind: holo
+      connections:
+        - name: eth-rt4
+          to: net4
+          ip: 192.168.0.14/30
+
+        - name: eth-rt6
+          to: net5
+          ip: 192.168.0.17/30
+
+        - name: eth-test
+          to: net-test
+          ip: 10.0.5.1/24
+
+    - name: rt6
+      kind: holo
+      connections:
+        - name: eth-rt5
+          to: net5
+          ip: 192.168.0.18/30
+
+        - name: eth-test
+          to: net-test
+          ip: 10.0.6.1/24

--- a/bgp/bgp-roles/rt1/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt1/etc.holo/holo.config
@@ -1,0 +1,41 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 1.1.1.1
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65101
+  bgp global identifier 1.1.1.1
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.2
+    peer-as 65102
+    local-role provider
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.0/30 30 30
+  prefixes prefix-list 10.0.1.0/24 24 24
+  prefixes prefix-list 1.1.1.1/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!

--- a/bgp/bgp-roles/rt2/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt2/etc.holo/holo.config
@@ -1,0 +1,52 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 2.2.2.2
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65102
+  bgp global identifier 2.2.2.2
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.1
+    peer-as 65101
+    local-role customer
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+  bgp neighbors neighbor 192.168.0.6
+    peer-as 65103
+    local-role customer 
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.4/30 30 30
+  prefixes prefix-list 192.168.0.0/30 30 30
+  prefixes prefix-list 10.0.2.0/24 24 24
+  prefixes prefix-list 2.2.2.2/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!

--- a/bgp/bgp-roles/rt3/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt3/etc.holo/holo.config
@@ -1,0 +1,52 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 3.3.3.3
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65103
+  bgp global identifier 3.3.3.3
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.5
+    peer-as 65102
+    local-role provider 
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+  bgp neighbors neighbor 192.168.0.10
+    peer-as 65104
+    local-role peer
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.4/30 30 30
+  prefixes prefix-list 192.168.0.8/30 30 30
+  prefixes prefix-list 10.0.3.0/24 24 24
+  prefixes prefix-list 3.3.3.3/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!

--- a/bgp/bgp-roles/rt4/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt4/etc.holo/holo.config
@@ -1,0 +1,52 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 4.4.4.4
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65104
+  bgp global identifier 4.4.4.4
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.9
+    peer-as 65103
+    local-role peer
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+  bgp neighbors neighbor 192.168.0.14
+    peer-as 65105
+    local-role customer
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.8/30 30 30
+  prefixes prefix-list 192.168.0.12/30 30 30
+  prefixes prefix-list 10.0.4.0/24 24 24
+  prefixes prefix-list 4.4.4.4/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!

--- a/bgp/bgp-roles/rt5/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt5/etc.holo/holo.config
@@ -1,0 +1,52 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 5.5.5.5
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65105
+  bgp global identifier 5.5.5.5
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.13
+    peer-as 65104
+    local-role provider
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+  bgp neighbors neighbor 192.168.0.18
+    peer-as 65106
+    local-role provider
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.12/30 30 30
+  prefixes prefix-list 192.168.0.16/30 30 30
+  prefixes prefix-list 10.0.5.0/24 24 24
+  prefixes prefix-list 5.5.5.5/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!

--- a/bgp/bgp-roles/rt6/etc.holo/holo.config
+++ b/bgp/bgp-roles/rt6/etc.holo/holo.config
@@ -1,0 +1,41 @@
+!
+interfaces interface lo
+ type iana-if-type:softwareLoopback
+ ipv4
+ ipv6
+ !
+ ipv4 address 6.6.6.6
+  prefix-length 32
+ !
+!
+routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
+  bgp global as 65106
+  bgp global identifier 6.6.6.6
+  bgp global afi-safis afi-safi iana-bgp-types:ipv4-unicast
+    !
+    enabled true
+    apply-policy import-policy REDIST
+    ipv4-unicast redistribution ietf-routing:direct
+  !
+  bgp neighbors neighbor 192.168.0.17
+    peer-as 65105
+    local-role customer
+    !
+    afi-safis afi-safi iana-bgp-types:ipv4-unicast
+      enabled true
+      apply-policy default-import-policy accept-route
+      apply-policy default-export-policy accept-route
+    !
+  !
+!
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
+  !
+  prefixes prefix-list 192.168.0.16/30 30 30
+  prefixes prefix-list 10.0.6.0/24 24 24
+  prefixes prefix-list 6.6.6.6/32 32 32
+!
+routing-policy policy-definitions policy-definition REDIST
+  statements statement 1
+    conditions match-prefix-set prefix-set LOCAL
+    actions policy-result accept-route
+!


### PR DESCRIPTION
Add topology for verification of RFC 9234.
Meant to be tested alongside changes introduced in https://github.com/holo-routing/holo/pull/120